### PR TITLE
pip install conda-forge like

### DIFF
--- a/.github/workflows/macOS.yaml
+++ b/.github/workflows/macOS.yaml
@@ -35,7 +35,5 @@ jobs:
         export MUMPS_LIB="$(conda info --base)/envs/EnvMacOS/lib"
         export MUMPS_SOLVERS="dmumps,cmumps,zmumps,smumps"
         export DYLD_LIBRARY_PATH="$MUMPS_LIB:$DYLD_LIBRARY_PATH"
-        python setup.py build_ext --inplace
-        pip install .
+        pip install . -vv --global-option="build_ext" --global-option="--inplace"
         pytest ${{ github.workspace }}/tests
-        

--- a/.github/workflows/macOS.yaml
+++ b/.github/workflows/macOS.yaml
@@ -35,5 +35,5 @@ jobs:
         export MUMPS_LIB="$(conda info --base)/envs/EnvMacOS/lib"
         export MUMPS_SOLVERS="dmumps,cmumps,zmumps,smumps"
         export DYLD_LIBRARY_PATH="$MUMPS_LIB:$DYLD_LIBRARY_PATH"
-        pip install . --no-deps -vv --global-option="build_ext" --global-option="--inplace"
+        pip install . --no-deps -vv --config-settings="build_ext" --config-settings="--inplace"
         pytest ${{ github.workspace }}/tests

--- a/.github/workflows/macOS.yaml
+++ b/.github/workflows/macOS.yaml
@@ -35,5 +35,5 @@ jobs:
         export MUMPS_LIB="$(conda info --base)/envs/EnvMacOS/lib"
         export MUMPS_SOLVERS="dmumps,cmumps,zmumps,smumps"
         export DYLD_LIBRARY_PATH="$MUMPS_LIB:$DYLD_LIBRARY_PATH"
-        pip install . --no-deps -vv --config-settings="build_ext" --config-settings="--inplace"
+        pip install . --no-deps -vv --config-settings="--build-option=build_ext" --config-settings="--build-option=--inplace
         pytest ${{ github.workspace }}/tests

--- a/.github/workflows/macOS.yaml
+++ b/.github/workflows/macOS.yaml
@@ -35,5 +35,5 @@ jobs:
         export MUMPS_LIB="$(conda info --base)/envs/EnvMacOS/lib"
         export MUMPS_SOLVERS="dmumps,cmumps,zmumps,smumps"
         export DYLD_LIBRARY_PATH="$MUMPS_LIB:$DYLD_LIBRARY_PATH"
-        pip install . --no-deps -vv --config-settings="--build-option=build_ext" --config-settings="--build-option=--inplace
+        pip install . --no-deps -vv --global-option="build_ext" --global-option="--inplace"
         pytest ${{ github.workspace }}/tests

--- a/.github/workflows/macOS.yaml
+++ b/.github/workflows/macOS.yaml
@@ -35,5 +35,5 @@ jobs:
         export MUMPS_LIB="$(conda info --base)/envs/EnvMacOS/lib"
         export MUMPS_SOLVERS="dmumps,cmumps,zmumps,smumps"
         export DYLD_LIBRARY_PATH="$MUMPS_LIB:$DYLD_LIBRARY_PATH"
-        pip install . -vv --global-option="build_ext" --global-option="--inplace"
+        pip install . --no-deps -vv --global-option="build_ext" --global-option="--inplace"
         pytest ${{ github.workspace }}/tests

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -34,7 +34,5 @@ jobs:
         export MUMPS_INC="$(conda info --base)/envs/EnvUbuntu/include"
         export MUMPS_LIB="$(conda info --base)/envs/EnvUbuntu/lib"
         export MUMPS_SOLVERS="dmumps,cmumps,zmumps,smumps"
-        python setup.py build_ext --inplace
-        pip install .
+        pip install . -vv --global-option="build_ext" --global-option="--inplace"
         pytest ${{ github.workspace }}/tests
-        

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -34,5 +34,5 @@ jobs:
         export MUMPS_INC="$(conda info --base)/envs/EnvUbuntu/include"
         export MUMPS_LIB="$(conda info --base)/envs/EnvUbuntu/lib"
         export MUMPS_SOLVERS="dmumps,cmumps,zmumps,smumps"
-        pip install . --no-deps -vv --global-option="build_ext" --global-option="--inplace"
+        pip install . --no-deps -vv --config-settings="build_ext" --config-settings="--inplace"
         pytest ${{ github.workspace }}/tests

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -34,5 +34,5 @@ jobs:
         export MUMPS_INC="$(conda info --base)/envs/EnvUbuntu/include"
         export MUMPS_LIB="$(conda info --base)/envs/EnvUbuntu/lib"
         export MUMPS_SOLVERS="dmumps,cmumps,zmumps,smumps"
-        pip install . -vv --global-option="build_ext" --global-option="--inplace"
+        pip install . --no-deps -vv --global-option="build_ext" --global-option="--inplace"
         pytest ${{ github.workspace }}/tests

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -34,5 +34,5 @@ jobs:
         export MUMPS_INC="$(conda info --base)/envs/EnvUbuntu/include"
         export MUMPS_LIB="$(conda info --base)/envs/EnvUbuntu/lib"
         export MUMPS_SOLVERS="dmumps,cmumps,zmumps,smumps"
-        pip install . --no-deps -vv --config-settings="--build-option=build_ext" --config-settings="--build-option=--inplace
+        pip install . --no-deps -vv --global-option="build_ext" --global-option="--inplace"
         pytest ${{ github.workspace }}/tests

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -34,5 +34,5 @@ jobs:
         export MUMPS_INC="$(conda info --base)/envs/EnvUbuntu/include"
         export MUMPS_LIB="$(conda info --base)/envs/EnvUbuntu/lib"
         export MUMPS_SOLVERS="dmumps,cmumps,zmumps,smumps"
-        pip install . --no-deps -vv --config-settings="build_ext" --config-settings="--inplace"
+        pip install . --no-deps -vv --config-settings="--build-option=build_ext" --config-settings="--build-option=--inplace
         pytest ${{ github.workspace }}/tests

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -36,5 +36,5 @@ jobs:
         $env:MUMPS_LIB = Join-Path $env:CONDA_PREFIX 'Library\lib'
         $env:MUMPS_SOLVERS = 'dmumps,cmumps,zmumps,smumps'
         $env:PATH = "$env:PATH;$env:MUMPS_LIB"
-        pip install . --no-deps -vv --global-option="build_ext" --global-option="--inplace" --global-option="--compiler=msvc"
+        pip install . --no-deps -vv --config-settings="build_ext" --config-settings="--inplace" --config-settings="--compiler=msvc"
         pytest -q tests

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -36,6 +36,5 @@ jobs:
         $env:MUMPS_LIB = Join-Path $env:CONDA_PREFIX 'Library\lib'
         $env:MUMPS_SOLVERS = 'dmumps,cmumps,zmumps,smumps'
         $env:PATH = "$env:PATH;$env:MUMPS_LIB"
-        python setup.py build_ext --inplace --compiler=msvc
-        pip install .
-        pytest -q tests        
+        pip install . -vv --global-option="build_ext" --global-option="--inplace" --global-option="--compiler=msvc"
+        pytest -q tests

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -36,5 +36,5 @@ jobs:
         $env:MUMPS_LIB = Join-Path $env:CONDA_PREFIX 'Library\lib'
         $env:MUMPS_SOLVERS = 'dmumps,cmumps,zmumps,smumps'
         $env:PATH = "$env:PATH;$env:MUMPS_LIB"
-        pip install . --no-deps -vv --config-settings="build_ext" --config-settings="--inplace" --config-settings="--compiler=msvc"
+        pip install . --no-deps -vv --config-settings="--build-option=build_ext" --config-settings="--build-option=--inplace" --config-settings="--build-option=--compiler=msvc"
         pytest -q tests

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -36,5 +36,5 @@ jobs:
         $env:MUMPS_LIB = Join-Path $env:CONDA_PREFIX 'Library\lib'
         $env:MUMPS_SOLVERS = 'dmumps,cmumps,zmumps,smumps'
         $env:PATH = "$env:PATH;$env:MUMPS_LIB"
-        pip install . -vv --global-option="build_ext" --global-option="--inplace" --global-option="--compiler=msvc"
+        pip install . --no-deps -vv --global-option="build_ext" --global-option="--inplace" --global-option="--compiler=msvc"
         pytest -q tests

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ topdir = os.path.abspath(os.path.dirname(__file__))
 
 metadata = {
     "name": "mumps4py",
-    "version": "0.1.1rc0",
+    "version": "1.0.0",
     "description": "MUMPS for Python",
     "long_description": open(os.path.join(topdir, 'README.md')).read() if \
     os.path.exists(os.path.join(topdir, 'README.md')) else "A Python interface to the MUMPS solver library",

--- a/setup.py
+++ b/setup.py
@@ -255,7 +255,7 @@ def run_setup():
             'clean': CleanCommand,
             'sdist': sdist,
         },
-        install_requires=[],
+        install_requires=['numpy', 'mpi4py', f'Cython>={CYTHON_VERSION}'],
         zip_safe=False,
         **metadata
     )

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ metadata = {
 
 }
 
-CYTHON_VERSION = '0.29.26'
+CYTHON_VERSION = '3.0.0'
 
 # --------------------------------------------------------------------
 # Helper Functions
@@ -255,7 +255,7 @@ def run_setup():
             'clean': CleanCommand,
             'sdist': sdist,
         },
-        install_requires=['numpy', 'mpi4py', f'Cython>={CYTHON_VERSION}'],
+        install_requires=[],
         zip_safe=False,
         **metadata
     )


### PR DESCRIPTION
conda forge prefere installer sans appeler explicitement le setup.py  (https://github.com/conda-forge/staged-recipes?tab=readme-ov-file#7-when-or-why-do-i-need-to-use--python---m-pip-install---vv) 
Je teste une modification